### PR TITLE
cookie consent message changed & cookie consent link added

### DIFF
--- a/edx-platform/utec/lms/templates/widgets/cookie-consent.html
+++ b/edx-platform/utec/lms/templates/widgets/cookie-consent.html
@@ -1,0 +1,47 @@
+<!-- Cookie Consent -->
+<%page expression_filter="h"/>
+<%! from django.utils.translation import ugettext as _ %>
+<%namespace name='static' file='../static_content.html'/>
+ 
+<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.1/cookieconsent.min.css" />
+<script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.1/cookieconsent.min.js"></script>
+
+<script>
+window.addEventListener("load", function(){
+  window.cookieconsent.initialise({
+
+    window: '<div dir="${static.dir_rtl()}" role="dialog" tabindex="-1" id="cookiepopup" aria-label="cookieconsent" class="cc-window {{classes}}"><!--googleoff: all-->{{children}}<!--googleon: all--></div>',
+
+    palette:{
+      popup: {background: "#323538", text: "#ffffff"},
+      button: {background: "#005379", text: "#ffffff"},
+    },
+    "content": {
+      "message": "Utilizamos cookies para optimizar el uso de la Plataforma, siendo algunas de ellas necesarias para que la misma cumpla con sus funcionalidades. Si continúas haciendo uso de la Plataforma, consideraremos que aceptas las cookies empleadas. Puedes obtener más información leyendo nuestra ",
+      "dismiss": "Entendido!",
+      "link": "Política de cookies",
+      "href": "https://edu.utec.edu.uy/politicas-de-cookies/"
+    },
+    theme: "classic",
+    "elements": {
+        "dismiss": '<a aria-label="dismiss cookie message" id="dismiss" role=button tabindex="2" class="cc-btn cc-dismiss:focus">{{dismiss}}</a>',
+    },
+    "position": "bottom",
+    "static": "true"
+  },
+  function(popup){
+
+    $(".cc-window").on('keydown', function(event) {
+      if (event.keyCode == 27 ){
+        popup.close();
+      } 
+    });
+
+    $("#dismiss").on('keydown', function(event) {
+      if (event.keyCode == 13 || event.keyCode == 32 ) {
+        popup.onButtonClick(event);
+      }
+    });  
+  });
+});
+</script>


### PR DESCRIPTION
## Description
- The cookie consent link to https://edu.utec.edu.uy/politicas-de-cookies/ was added

- The cookie consent message was changed

## Testing instructions
- Enable cookie consent variable ("FEATURES": {"ENABLE_COOKIE_CONSENT":true})
- Cookie consent banner should appear

**Previous version commit:** 68447c0