### PR TITLE
MODAL COOKIES

### DIFF
--- a/edx-platform/utec/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/utec/lms/static/sass/partials/lms/theme/_extras.scss
@@ -550,3 +550,44 @@ footer.footer {
     }
   }
 }
+
+ // Modal tos
+
+ .modal-container {
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: none;
+}
+
+.modal-content {
+  background-color: #fefefe;
+  margin: 15% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  max-width: 600px;
+  border-radius: 10px;
+  text-align: justify;
+  box-shadow: -7px 8px 20px 2px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+button.button-modal {
+  border-radius: 5px;
+  margin-top: 15px;
+  width: 200px;
+
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: #0066a2;
+    box-shadow: none;
+  }
+}

--- a/edx-platform/utec/lms/templates/footer.html
+++ b/edx-platform/utec/lms/templates/footer.html
@@ -5,10 +5,20 @@
   from django.utils.translation import ugettext as _
   from branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
+  from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
+  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <% footer = get_footer(is_secure=is_secure) %>
 <% icp_license_info = getattr(settings, 'ICP_LICENSE_INFO', {})%>
 <%namespace name='static' file='static_content.html'/>
+
+<%
+options_modal = configuration_helpers.get_value("MODAL_COOKIES", {})
+modal_force_display = options_modal.get("modal_force_display", False)
+name_preference_cookies = options_modal.get("modal_cookies_name_preference", "")
+modal_cookies_text = options_modal.get('modal_cookies_text', "")
+modal_cookies_btn_label = options_modal.get('modal_cookies_btn_label', "")
+%>
 
 <footer class="footer">
   <div class="wrapper-footer">
@@ -62,3 +72,65 @@
   % endfor
 % endif
 
+%if modal_force_display:
+## Pop-up cookies
+<div class="modal-container">
+  <div class="modal-content">
+     % if modal_tos_text:
+    ${modal_tos_text | n}
+    % endif
+    <button class="button-modal btn-primary">${modal_cookies_btn_label}</button>
+  </div>
+
+</div>
+
+  %if user.is_authenticated:
+  <% value_preference = get_user_preference(user, name_preference_cookies) %>
+
+  <script type="text/javascript">
+  
+  const newCookiesModal = (function () {
+      const valuePreference = '${value_preference}';
+      const urlPreferenceCookies = '/api/user/v1/preferences/${user}/${name_preference_cookies}';
+
+      function displayModal() {
+        $('.modal-container').css('display', 'block');
+      }
+
+      function hideModal() {
+        $('.modal-container').css('display', 'none');
+      }
+
+      function updatePreference() {
+        $.ajax({
+          url: urlPreferenceCookies,
+          type: 'PUT',
+          dataType: 'json',
+          contentType: "application/json",
+          data: "true"
+        });
+      }
+
+      function getPreference() {  
+        (valuePreference == 'True') ? hideModal() : displayModal();     
+        events();
+      }
+
+      function events() {
+        $('.button-modal').on('click', function(){
+          hideModal();
+          updatePreference();
+        });
+      }
+      return {
+        getPreference: getPreference
+      }
+    })();
+
+    $(window).load (function (){
+      newCookiesModal.getPreference();
+    });
+
+  </script>
+  %endif
+%endif


### PR DESCRIPTION
Modal to accept consent cookies

In this PR a modal component was created to accept consent cookies. The logic of this modal was added to the footer template. This component is displayed in the control panel and cannot continue until new TOS are accepted. It is saved in a new variable in the user preferences, so it is not necessary to accept it when the user logs in again.

Modal text can be changed from site configuration.

The following variables of general use were defined

{
   "MODAL_COOKIES":{
      "modal_force_display":true,
      "modal_cookies_name_preference":"update_tos_2021_12_01",
      "modal_cookies_text":"<h2>Utilizamos cookies para optimizar el uso de la Plataforma, siendo algunas de ellas necesarias para que la misma cumpla con sus funcionalidades. Si continuas haciendo uso de la Plataforma, consideraremos que aceptas las cookies empleadas. Puedes obtener más información leyendo nuestra  <a aria-label='learn more about cookies' tabindex='0' href='https://edu.utec.edu.uy/politicas-de-cookies/' target='_blank'>Política de cookies</a></h2>",
      "modal_cookies_btn_label":"Entendido"
   }
}
Screenshot

![Screenshot from 2021-07-28 21-11-05](https://user-images.githubusercontent.com/66017940/127533318-6f752712-18e4-4385-90ad-eb22741daba5.png)


Stage https://utec.edunextstage.net/