### PR TITLE
fix isuue with modal cookies 

### DIFF
--- a/edx-platform/utec/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/utec/lms/static/sass/partials/lms/theme/_extras.scss
@@ -555,7 +555,7 @@ footer.footer {
 
  .modal-container {
   position: fixed;
-  z-index: 1;
+  z-index: 100;
   left: 0;
   top: 0;
   width: 100%;
@@ -580,7 +580,6 @@ footer.footer {
 }
 
 button.button-modal {
-  border-radius: 5px;
   margin-top: 15px;
   width: 200px;
 

--- a/edx-platform/utec/lms/templates/footer.html
+++ b/edx-platform/utec/lms/templates/footer.html
@@ -5,20 +5,10 @@
   from django.utils.translation import ugettext as _
   from branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
-  from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
-  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <% footer = get_footer(is_secure=is_secure) %>
 <% icp_license_info = getattr(settings, 'ICP_LICENSE_INFO', {})%>
 <%namespace name='static' file='static_content.html'/>
-
-<%
-options_modal = configuration_helpers.get_value("MODAL_COOKIES", {})
-modal_force_display = options_modal.get("modal_force_display", False)
-name_preference_cookies = options_modal.get("modal_cookies_name_preference", "")
-modal_cookies_text = options_modal.get('modal_cookies_text', "")
-modal_cookies_btn_label = options_modal.get('modal_cookies_btn_label', "")
-%>
 
 <footer class="footer">
   <div class="wrapper-footer">
@@ -71,66 +61,3 @@ modal_cookies_btn_label = options_modal.get('modal_cookies_btn_label', "")
     <link rel="stylesheet" type="text/css" href="${url}"></link>
   % endfor
 % endif
-
-%if modal_force_display:
-## Pop-up cookies
-<div class="modal-container">
-  <div class="modal-content">
-     % if modal_tos_text:
-    ${modal_tos_text | n}
-    % endif
-    <button class="button-modal btn-primary">${modal_cookies_btn_label}</button>
-  </div>
-
-</div>
-
-  %if user.is_authenticated:
-  <% value_preference = get_user_preference(user, name_preference_cookies) %>
-
-  <script type="text/javascript">
-  
-  const newCookiesModal = (function () {
-      const valuePreference = '${value_preference}';
-      const urlPreferenceCookies = '/api/user/v1/preferences/${user}/${name_preference_cookies}';
-
-      function displayModal() {
-        $('.modal-container').css('display', 'block');
-      }
-
-      function hideModal() {
-        $('.modal-container').css('display', 'none');
-      }
-
-      function updatePreference() {
-        $.ajax({
-          url: urlPreferenceCookies,
-          type: 'PUT',
-          dataType: 'json',
-          contentType: "application/json",
-          data: "true"
-        });
-      }
-
-      function getPreference() {  
-        (valuePreference == 'True') ? hideModal() : displayModal();     
-        events();
-      }
-
-      function events() {
-        $('.button-modal').on('click', function(){
-          hideModal();
-          updatePreference();
-        });
-      }
-      return {
-        getPreference: getPreference
-      }
-    })();
-
-    $(window).load (function (){
-      newCookiesModal.getPreference();
-    });
-
-  </script>
-  %endif
-%endif

--- a/edx-platform/utec/lms/templates/header/header.html
+++ b/edx-platform/utec/lms/templates/header/header.html
@@ -16,7 +16,14 @@ from openedx.core.djangolib.markup import HTML, Text
 from branding import api as branding_api
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+<%
+options_modal = configuration_helpers.get_value("MODAL_COOKIES", {})
+modal_force_display = options_modal.get("modal_force_display", False)
+name_preference_cookies = options_modal.get("modal_cookies_name_preference", "")
+modal_cookies_text = options_modal.get('modal_cookies_text', "")
+modal_cookies_btn_label = options_modal.get('modal_cookies_btn_label', "")
 %>
 
 ## Provide a hook for themes to inject branding on top.
@@ -115,3 +122,38 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         </form>
     % endif
 % endif
+%if modal_force_display:
+## Pop-up cookies
+<div class="modal-container">
+  <div class="modal-content">
+    ${modal_cookies_text | n}
+    <button class="button-modal btn-primary">${modal_cookies_btn_label}</button>
+  </div>
+</div>
+<script type="text/javascript">
+const cookieAcceptance = localStorage.getItem("cookie-acceptance");
+
+function displayModal() {
+  $(".modal-container").css("display", "block");
+}
+
+function hideModal() {
+  $(".modal-container").css("display", "none");
+}
+function events() {
+  $(".button-modal").on("click", function () {
+    localStorage.setItem("cookie-acceptance", "True");
+    hideModal();
+  });
+}
+
+$(document).ready(function () {
+  if (cookieAcceptance === null) {
+    displayModal();
+    events();
+  }
+});
+
+</script>
+  
+%endif


### PR DESCRIPTION
In this pr, the authenticated user conditional was eliminated because the client requested that the cookie acceptance modal should not allow the user to register or sign in without having accepted the cookies.

Therefore, the modal script was changed to the header template, since the footer template only appears when the user has signed in.

![Screenshot from 2021-07-30 08-33-37](https://user-images.githubusercontent.com/66017940/127660631-1fc00c4a-33ea-4400-98eb-e6626d95dba4.png)

